### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/src/util/general.ts
+++ b/src/util/general.ts
@@ -2,6 +2,9 @@
 export function deepMerge(target: any, source: any): any {
     for (const key in source) {
         if (Object.prototype.hasOwnProperty.call(source, key)) {
+            if (key === "__proto__" || key === "constructor") {
+                continue;
+            }
             if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
                 if (!target[key]) {
                     target[key] = {};


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/summnir/security/code-scanning/2](https://github.com/tobrien/summnir/security/code-scanning/2)

To fix the issue, we need to explicitly block the special property names `__proto__` and `constructor` from being copied from the `source` object to the `target` object. This can be achieved by adding a condition to skip these property names during the iteration over `source`.

The fix involves:
1. Adding a check to skip keys named `__proto__` or `constructor` in the `for` loop on line 3.
2. Ensuring that the rest of the functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
