### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
       - 'release/**'
       - 'feature/**'
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/summnir/security/code-scanning/1](https://github.com/tobrien/summnir/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's steps:
- `contents: read` is needed for actions like `actions/checkout` to read the repository contents.
- `statuses: write` is required for `codecov/codecov-action` to update commit statuses with coverage results.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
